### PR TITLE
[update] カルーセルの修正

### DIFF
--- a/components/work/Viewer.vue
+++ b/components/work/Viewer.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="container">
-		<hooper :itemsToShow="1" style="height: 100%;">
-			<slide v-for="mediaAsset in mediaAssets" :key="mediaAsset.id" style="height: auto;">
+		<hooper :settings="options" style="height: 100%;">
+			<slide v-for="mediaAsset in mediaAssets" :key="mediaAsset.id" style="width: 100%">
 				<you-tube v-if="mediaAsset.youtube_video_id !== null" :youtubeID="mediaAsset.youtube_video_id" />
 				<image-asset v-if="mediaAsset.image !== null" :src="mediaAsset.image" />
 				<sound-cloud v-if="mediaAsset.soundcloud_embed_html !== ''" :soundcloudEmbedHTML="mediaAsset.soundcloud_embed_html" />
@@ -32,6 +32,15 @@ import Sketchfab from './medias/Sketchfab.vue'
 
 export default {
 	name: 'Viewer',
+	data () {
+		return {
+			options: {
+				itemsToShow: 1,
+				wheelControl: false,
+				centerMode: true
+      },
+		}
+	},
 	components: {
 		Hooper,
 		Slide,
@@ -40,7 +49,7 @@ export default {
 		YouTube,
 		ImageAsset,
 		SoundCloud,
-Sketchfab
+		Sketchfab
 	},
 	props: {
 		mediaAssets: {

--- a/components/work/Viewer.vue
+++ b/components/work/Viewer.vue
@@ -37,7 +37,8 @@ export default {
 			options: {
 				itemsToShow: 1,
 				wheelControl: false,
-				centerMode: true
+				centerMode: true,
+				infiniteScroll: true
       },
 		}
 	},


### PR DESCRIPTION
slideコンポーネントにstyleでwidth:100%を適応することで修正出来た

追加で変更したところ
* カルーセルをマウスホイールでのスライドさせないようにした
  *  ページの下部の作品コメントやコメントを見るためにスクロールするためのユーザービリティを尊重したためです。

今後の検討
カルーセルの無限スクロールを可能にするかどうか、１行追加するだけなのでprokumaCTOの判断に任せます。