### PR TITLE
[fix] #156 区切れのない英文を折り返すよう修正

### DIFF
--- a/components/work/_comment.vue
+++ b/components/work/_comment.vue
@@ -45,6 +45,7 @@ export default {
 }
 .comment-text {
 	padding: 0 5px;
+	word-break: break-all;
 }
 .comment-text::selection, .comment-name::selection {
 	background: #4565863d;


### PR DESCRIPTION
改行するようになりました．
![image](https://user-images.githubusercontent.com/65777862/126102271-28a1ddf7-da1f-4d11-9c0d-e947c0ef9af4.png)
