### PR TITLE
[update] #183 カルーセルのスライドボタンを大きくして白枠にした

### DIFF
--- a/components/work/Viewer.vue
+++ b/components/work/Viewer.vue
@@ -75,3 +75,12 @@ export default {
 	text-align: center;
 }
 </style>
+
+<style>
+.hooper-next svg, .hooper-prev svg {
+	width: 45px;
+	height: 45px;
+	fill: rgba(0, 0, 0, 0.5);
+	stroke: rgba(255, 255, 255, 0.5);
+}
+</style>

--- a/components/work/Viewer.vue
+++ b/components/work/Viewer.vue
@@ -81,6 +81,9 @@ export default {
 	width: 45px;
 	height: 45px;
 	fill: rgba(0, 0, 0, 0.5);
-	stroke: rgba(255, 255, 255, 0.5);
+	background-color: rgba(255, 255, 255, 0.2);
+}
+.hooper-next svg:hover, .hooper-prev svg:hover {
+	background-color: rgba(255, 255, 255, 0.5);
 }
 </style>


### PR DESCRIPTION
<img width="499" alt="スクリーンショット 2021-07-19 20 52 26" src="https://user-images.githubusercontent.com/65497260/126156045-4bbd63c1-f90f-43f2-a81c-20b6400eb337.png">
こんなのはどうでしょう