### PR TITLE
[fix] #210 画像ごとスクロールされるバグを修正

### DIFF
--- a/components/community/Card.vue
+++ b/components/community/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <nuxt-link :to="workPath" class="card-link">
+  <div @click="$router.push(workPath)" class="card-link">
     <article class="card">
       <img :src="card_image" alt="thumbnail" title="thumbnail" class="thumbnail"/>
       <div class="tag_viewer1" v-if="isHoverFlag">
@@ -20,7 +20,7 @@
           <div class="description">{{description}}</div>
       </div>
     </article>
-  </nuxt-link>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
nuxt-linkタグを使っていたのをdivタグを使うことでバグを回避を試みた

#211 では別のファイルのコミットを間違えてあげてしまったため、改めてブランチを作りました。