### PR TITLE
[update] #217 work-linkがはみ出す場合...(省略文字)を表示

### DIFF
--- a/components/work/WorkLink.vue
+++ b/components/work/WorkLink.vue
@@ -26,4 +26,9 @@ export default {
   margin-right: 0.5rem;
 	color: #000000;
 }
+.bold {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
 </style>


### PR DESCRIPTION
省略する際のcss文字列を表示するクラスに適応
```
 text-overflow: ellipsis;
 white-space: nowrap;
 overflow: hidden;
  ```