### PR TITLE
[fix] #220 作品一覧のコミュニティ説明のCSS修正

### DIFF
--- a/components/community/Description.vue
+++ b/components/community/Description.vue
@@ -27,6 +27,7 @@ div{
 }
 .allWrapper {
 	margin: 0;
+	width: 100%;
 }
 .name {
 	color: var(--base-color);


### PR DESCRIPTION
widthの大きい時のCGコミュニティ説明文(変な所で折り返していない)
![image](https://user-images.githubusercontent.com/65777862/126345502-300efc2e-4698-4284-a622-dbab9f2e98fd.png)
  
widthの小さい時のMediaArtコミュニティ説明文
![image](https://user-images.githubusercontent.com/65777862/126345924-4c7009c6-6b5b-469f-b17f-abf915b67987.png)
